### PR TITLE
Update set_modata_selection_r18.py

### DIFF
--- a/scripts/05_modules/mograph/set_modata_selection_r18.py
+++ b/scripts/05_modules/mograph/set_modata_selection_r18.py
@@ -23,6 +23,11 @@ def main():
     # Builds list for clones selection states
     states = [1] * op[c4d.MG_LINEAR_COUNT]
 
+    # Create MoGraph Selection Tag on the cloner to store the selection
+    tag = op.MakeTag(c4d.Tmgselection)
+    if tag is None:
+        raise RuntimeError("Failed to create a MoGraph Selection Tag on the selected object.")
+        
     # Creates new BaseSelect and sets it to states list
     selection = c4d.BaseSelect()
     selection.SetAll(states)


### PR DESCRIPTION
Something I found confusing in the [Set MoData Selection Example](https://github.com/Maxon-Computer/Cinema-4D-Python-API-Examples/blob/master/scripts/05_modules/mograph/set_modata_selection_r18.py) is that it's not clear what to do with the selection.

Wouldn't it make sense to add a `op.MakeTag(c4d.Tmgselection)` before calling `GeSetMoDataSelection`?

This way, also the [Get MoData Selection Example](https://github.com/Maxon-Computer/Cinema-4D-Python-API-Examples/blob/master/scripts/05_modules/mograph/get_modata_selection_r18.py) works with it in a tandem.

If you don't agree, I'd be curious why this doesn't make sense.
Thanks!